### PR TITLE
Added "support" for debian 11 CiS file 

### DIFF
--- a/cis_pdf_parser.py
+++ b/cis_pdf_parser.py
@@ -69,6 +69,8 @@ def main():
             logger.info("*** Document found name: {} ***".format(CISName))
             if "Red Hat Enterprise Linux 7" in CISName:
                 pattern = "(\d+(?:\.\d.\d*)+)(.*?)(\(Automated\)|\(Manual\))"
+            elif "Debian Linux 11" in CISName:
+                pattern = "(\d+(?:\.\d.\d*)+)(.*?)(\(Automated\)|\(Manual\))"
             elif "Microsoft Windows Server 2019" in CISName:
                 pattern = "(\d+(?:\.\d+)+)\s\(((L[12])|(NG))\)(.*?)(\(Automated\)|\(Manual\))"
             elif "Microsoft Windows 10 Enterprise" in CISName:
@@ -202,8 +204,8 @@ def main():
                         rat_count,
                         acnt,
                         rem_count,
-                        defval_count,
-                        cis_count,
+                        #defval_count,
+                        #cis_count,
                     ]
                     logging.debug(row_count)
                     if row_count.count(row_count[0]) == len(row_count):


### PR DESCRIPTION
I needed to do the exercises with Debian 11 CiS, which worked with just a few modifications. 
The data collected may not be exhaustive but the main things are in the CSV. 

So I added the choice of Debian 11 in the CISname
I commented   defval_count  cis_count because it was not able to get the data entirely otherwise. 
Because cis control isn't always there either hence the fix to increment default value is no more working. 

It ended up that I still have the good default value when one exists and the CIS controls are written as well at the good place.
Maybe they are better changes to make in order to be more optimized. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
